### PR TITLE
删除 google play instant 的 reload 监听

### DIFF
--- a/libs/js/android-instant-downloader.js
+++ b/libs/js/android-instant-downloader.js
@@ -25,7 +25,7 @@
 
 const ANDROID_INSTANT_DOWNLOAD_PIPE = 'AndroidInstantDownloader';
 const MAX_DOWNLOAD_TASK = 32;
-const TIME_SECONDS = 60;
+const TIME_SECONDS = 10;
 const FILE_NAME_SUFFIX = 'game';
 
 const INSTANT_REMOTE_SERVER = '';

--- a/libs/js/android-instant-downloader.js
+++ b/libs/js/android-instant-downloader.js
@@ -25,7 +25,7 @@
 
 const ANDROID_INSTANT_DOWNLOAD_PIPE = 'AndroidInstantDownloader';
 const MAX_DOWNLOAD_TASK = 32;
-const TIME_SECONDS = 10;
+const TIME_SECONDS = 20;
 const FILE_NAME_SUFFIX = 'game';
 
 const INSTANT_REMOTE_SERVER = '';

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.1",
     "description": "Google Play Instant Importer",
     "author": "Cocos Creator",
-    "main": "main.js"
+    "main": "main.js",
+    "ignoreWatch": true
   }
   


### PR DESCRIPTION
1.删除 google play instant 的 reload 监听
2.timeout 时间改为20s，60太长了没必要

主要为了临时解决win10上的问题
https://github.com/cocos-creator/2d-tasks/issues/674