### PR TITLE
do not download script for android instant platform

### DIFF
--- a/libs/js/android-instant-downloader.js
+++ b/libs/js/android-instant-downloader.js
@@ -77,7 +77,7 @@ let AndroidInstantDownloaderPipe = function () {
 };
 
 AndroidInstantDownloaderPipe.prototype.handle = function (item, callback) {
-    if (jsb.fileUtils.isFileExist(item.url)) {
+    if (item.url.endsWith('.js') || jsb.fileUtils.isFileExist(item.url)) {
         return item;
     }
 

--- a/libs/js/android-instant-downloader.js
+++ b/libs/js/android-instant-downloader.js
@@ -77,6 +77,7 @@ let AndroidInstantDownloaderPipe = function () {
 };
 
 AndroidInstantDownloaderPipe.prototype.handle = function (item, callback) {
+    // android-instant-downloader can only be used to download res
     if (item.url.endsWith('.js') || jsb.fileUtils.isFileExist(item.url)) {
         return item;
     }


### PR DESCRIPTION
jsc模式找不到js会走到download，但是我们并不支持脚本的下载，所以就屏蔽掉脚本的下载
https://github.com/cocos-creator/2d-tasks/issues/2138